### PR TITLE
Automatically import motion vector to armaObjProps if Arma tools are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ meant to be used with:
 
 * import of RTM files in RTM_0101 format
 * for each RTM frame a keyframe is added for every animated bone
+* if Arma Toolbox is installed, import motion vector automatically
 
 ## Known Issues ##
 

--- a/rtm_import.py
+++ b/rtm_import.py
@@ -30,6 +30,8 @@ import struct
 import bpy
 import mathutils
 import bpy_extras
+import importlib
+from importlib import util
 
 def read_rtm(file, verbose=False):
     signature = struct.unpack('8s', file.read(8))[0]
@@ -79,6 +81,12 @@ def import_rtm(rtm, frame_start=0, set_frame_range=True, mute_bone_constraints=T
 
     if result != 0:
         return (result, 0)
+
+    if not importlib.util.find_spec("RTMExporter") == None:
+    	bpy.context.object.armaObjProps.motionVector[0] = absolut_vector[0]
+	bpy.context.object.armaObjProps.motionVector[1] = absolut_vector[2]
+	bpy.context.object.armaObjProps.motionVector[2] = absolut_vector[1]
+
 
     pose = bpy.context.object.pose
     rig = bpy.context.object.data

--- a/rtm_import.py
+++ b/rtm_import.py
@@ -16,8 +16,8 @@
 bl_info = {
     "name": "RTM Import",
     "author": "4d4a5852",
-    "version": (0, 1, 0),
-    "blender": (2, 65, 0),
+    "version": (0, 2, 0),
+    "blender": (2, 78, 0),
     "location": "File -> Import",
     "description": "Import Arma 2/3 RTM files",
     "warning": "",
@@ -83,9 +83,9 @@ def import_rtm(rtm, frame_start=0, set_frame_range=True, mute_bone_constraints=T
         return (result, 0)
 
     if not importlib.util.find_spec("RTMExporter") == None:
-    	bpy.context.object.armaObjProps.motionVector[0] = absolut_vector[0]
-	bpy.context.object.armaObjProps.motionVector[1] = absolut_vector[2]
-	bpy.context.object.armaObjProps.motionVector[2] = absolut_vector[1]
+        bpy.context.object.armaObjProps.motionVector[0] = absolut_vector[0]
+        bpy.context.object.armaObjProps.motionVector[1] = absolut_vector[2]
+        bpy.context.object.armaObjProps.motionVector[2] = absolut_vector[1]
 
 
     pose = bpy.context.object.pose


### PR DESCRIPTION
I wrote little script to my friend. He wanted to import and export multiple rtm files. (I will create repo for that later)

After running files through import export, we noticed that motion vector was missing from new rtm files. This pull request add conditional feature to allow automatic importing. 

Implementation requires at least Python 3.4. Blender's documentation does not include Python version so that why version is updated to 2.78.0 (tested with 78c). I also updated RTM Import's version so versions can be identified.

Edit: Here is proof that this works: https://www.youtube.com/watch?v=xdlyfV__w84