### PR TITLE
Import to at

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Blender:
     * 'Disable Bone Constraints': needs to be set to get valid imports (for now)
     * 'Import motion vector': Import motion vector from RTM (for export with Arma Toolbox)
     * 'Create Action': Create new action and switch to it - name is based on the filename
+    * 'Import to @': Experimental option to import the RTM bone data to the Blender bones named with a prepended '@', e.g. RTM bone 'LeftHand' will be imported onto Blender bone '@LeftHand' - an appropriately set up Blender rig is required
 * 'Import RTM'
 * import will start - its progress will be shown at the mouse cursor
 

--- a/rtm_import.py
+++ b/rtm_import.py
@@ -171,7 +171,7 @@ class RTMIMPORT_OT_RtmImport(bpy.types.Operator, bpy_extras.io_utils.ImportHelpe
         description="Set first and final frame of the playback/rendering range",
         default=True)
     mute_bone_constraints: bpy.props.BoolProperty(
-        name="Disable Bone Constraints (RECOMMEND!)",
+        name="Disable Bone Constraints (RECOMMENDED)",
         description="Disable all bone constraints on the armature",
         default=True)
     import_motion_vector: bpy.props.BoolProperty(

--- a/rtm_import.py
+++ b/rtm_import.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 4d4a5852
+# Copyright (C) 2016-2021 4d4a5852
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Added `Import to @` feature:

Experimental option to import the RTM bone data to the Blender bones named with a prepended `@`
e.g. RTM bone `LeftHand` will be imported onto Blender bone `@LeftHand`
an appropriately set up Blender rig is required